### PR TITLE
feat: Add support for multiple page templates and sizes #1

### DIFF
--- a/app/src/main/java/au/com/gman/bottlerocket/domain/PageSizeEnum.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/domain/PageSizeEnum.kt
@@ -1,0 +1,7 @@
+package au.com.gman.bottlerocket.domain
+
+enum class PageSizeEnum {
+    UNKNOWN,
+    A4,
+    A5
+}

--- a/app/src/main/java/au/com/gman/bottlerocket/domain/PageTemplate.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/domain/PageTemplate.kt
@@ -1,6 +1,7 @@
 package au.com.gman.bottlerocket.domain
 
 data class PageTemplate(
-    val type: String,
+    val pageSize: PageSizeEnum,
+    val templateType: TemplateTypeEnum,
     val pageDimensions: RocketBoundingBox
 )

--- a/app/src/main/java/au/com/gman/bottlerocket/domain/TemplateTypeEnum.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/domain/TemplateTypeEnum.kt
@@ -1,0 +1,12 @@
+package au.com.gman.bottlerocket.domain
+
+enum class TemplateTypeEnum {
+    UNKNOWN,
+    STANDARD_LINED,
+    PROJECT_TASK_TRACKER,
+    MONTHLY_PAGE,
+    WEEKLY_PAGE,
+    OKRS_PAGE,
+    IDEAS_PAGE,
+    STANDARD_DOTTED
+}

--- a/app/src/main/java/au/com/gman/bottlerocket/qrCode/QrCodeHandler.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/qrCode/QrCodeHandler.kt
@@ -48,6 +48,8 @@ class QrCodeHandler @Inject constructor(
 
         if (barcode != null) {
             qrCodeValue = barcode.rawValue
+            Log.d(TAG, "QR code value found: $qrCodeValue")
+
             val qrCornerPoints = RocketBoundingBox(barcode.cornerPoints)
             qrCornerPointsBoxUnscaled = qrCornerPoints
 

--- a/app/src/main/java/au/com/gman/bottlerocket/qrCode/QrCodeTemplateMatcher.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/qrCode/QrCodeTemplateMatcher.kt
@@ -1,32 +1,125 @@
 package au.com.gman.bottlerocket.qrCode
 
 import android.graphics.PointF
+import au.com.gman.bottlerocket.domain.PageSizeEnum
 import au.com.gman.bottlerocket.domain.PageTemplate
 import au.com.gman.bottlerocket.domain.RocketBoundingBox
+import au.com.gman.bottlerocket.domain.TemplateTypeEnum
 import au.com.gman.bottlerocket.interfaces.IQrCodeTemplateMatcher
 import javax.inject.Inject
 import kotlin.collections.get
 
 class QrCodeTemplateMatcher @Inject constructor() : IQrCodeTemplateMatcher {
 
-    val templatesMap = mapOf(
-        "04o" to PageTemplate(
-            type = "1",
-            pageDimensions = RocketBoundingBox(
-                topLeft = PointF(0f, -25.0f),
-                topRight = PointF(15.0f, -25.0f),
-                bottomRight = PointF(15.0f, 1.0f),
+    companion object {
+        private val STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT =
+            RocketBoundingBox(
+                topLeft = PointF(0f, -11.0f),
+                topRight = PointF(9.0f, -11.0f),
+                bottomRight = PointF(9.0f, 1.0f),
                 bottomLeft = PointF(0f, 1.0f)
             )
+
+        private val STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT =
+            RocketBoundingBox(
+                topLeft = PointF(-8.0f, -11.0f),
+                topRight = PointF(1.0f, -11.0f),
+                bottomRight = PointF(1.0f, 1.0f),
+                bottomLeft = PointF(-8.0f, 1.0f)
+            )
+
+        private val STANDARD_A5_BOUNDS_QR_BOTTOM_LEFT =
+            RocketBoundingBox(
+                topLeft = PointF(0f, -25.0f),
+                topRight = PointF(15.5f, -25.0f),
+                bottomRight = PointF(15.5f, 1.0f),
+                bottomLeft = PointF(0f, 1.0f)
+            )
+
+        private val STANDARD_A5_BOUNDS_QR_BOTTOM_RIGHT =
+            RocketBoundingBox(
+                topLeft = PointF(-14.5f, -25.0f),
+                topRight = PointF(1.0f, -25.0f),
+                bottomRight = PointF(1.0f, 1.0f),
+                bottomLeft = PointF(-14.5f, 1.0f)
+            )
+    }
+
+    val templatesMap = mapOf(
+        "04o" to PageTemplate(
+            templateType = TemplateTypeEnum.STANDARD_LINED,
+            pageSize = PageSizeEnum.A5,
+            pageDimensions = STANDARD_A5_BOUNDS_QR_BOTTOM_LEFT
+        ),
+        "04p" to PageTemplate(
+            templateType = TemplateTypeEnum.STANDARD_DOTTED,
+            pageSize = PageSizeEnum.A5,
+            pageDimensions = STANDARD_A5_BOUNDS_QR_BOTTOM_RIGHT
         ),
         "P01 V1F T02 S000" to PageTemplate(
-            type = "1",
-            pageDimensions = RocketBoundingBox(
-                topLeft = PointF(0f, -11.5F),
-                topRight = PointF(9.5f, -11.5F),
-                bottomRight = PointF(9.5f, 1.0F),
-                bottomLeft = PointF(0F, 1.0F)
-            )
+            templateType = TemplateTypeEnum.STANDARD_LINED,
+            pageSize = PageSizeEnum.A4,
+            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
+        ),
+        "P01 V17 T02 S000" to PageTemplate(
+            templateType = TemplateTypeEnum.STANDARD_LINED,
+            pageSize = PageSizeEnum.A4,
+            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
+        ),
+        "P02 V1F T02 S000" to PageTemplate(
+            templateType = TemplateTypeEnum.STANDARD_LINED,
+            pageSize = PageSizeEnum.A4,
+            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT
+        ),
+        "P02 V17 T02 S000" to PageTemplate(
+            templateType = TemplateTypeEnum.STANDARD_LINED,
+            pageSize = PageSizeEnum.A4,
+            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT
+        ),
+        "P01 V17 T01 S000" to PageTemplate(
+            templateType = TemplateTypeEnum.STANDARD_DOTTED,
+            pageSize = PageSizeEnum.A4,
+            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
+        ),
+        "P02 V17 T01 S000" to PageTemplate(
+            templateType = TemplateTypeEnum.STANDARD_DOTTED,
+            pageSize = PageSizeEnum.A4,
+            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT
+        ),
+        "P01 V17 T03 S000" to PageTemplate(
+            templateType = TemplateTypeEnum.PROJECT_TASK_TRACKER,
+            pageSize = PageSizeEnum.A4,
+            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
+        ),
+        "P01 V17 T04 S000" to PageTemplate(
+            templateType = TemplateTypeEnum.WEEKLY_PAGE,
+            pageSize = PageSizeEnum.A4,
+            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT
+        ),
+        "P02 V17 T04 S000" to PageTemplate(
+            templateType = TemplateTypeEnum.WEEKLY_PAGE,
+            pageSize = PageSizeEnum.A4,
+            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
+        ),
+        "P01 V17 T05 S000" to PageTemplate(
+            templateType = TemplateTypeEnum.MONTHLY_PAGE,
+            pageSize = PageSizeEnum.A4,
+            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT
+        ),
+        "P01 V17 T06 S000" to PageTemplate(
+            templateType = TemplateTypeEnum.OKRS_PAGE,
+            pageSize = PageSizeEnum.A4,
+            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
+        ),
+        "P01 V17 T06 S000" to PageTemplate(
+            templateType = TemplateTypeEnum.OKRS_PAGE,
+            pageSize = PageSizeEnum.A4,
+            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
+        ),
+        "P01 V17 T07 S000" to PageTemplate(
+            templateType = TemplateTypeEnum.IDEAS_PAGE,
+            pageSize = PageSizeEnum.A4,
+            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT
         )
     )
 

--- a/app/src/main/java/au/com/gman/bottlerocket/scanning/SteadyFrameIndicator.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/scanning/SteadyFrameIndicator.kt
@@ -10,7 +10,7 @@ class SteadyFrameIndicator @Inject constructor() : ISteadyFrameIndicator {
 
     private var consecutiveFramesCount: Int = 0
 
-    private val consecutiveFramesRequired: Int = 60
+    private val consecutiveFramesRequired: Int = 30
 
     private var percentageComplete: Float = 0.0F
 


### PR DESCRIPTION
This commit significantly expands the application's ability to recognize different page types by introducing enums for page size and template type, and by adding a comprehensive map of known QR codes to their corresponding page layouts.

This enables the system to correctly identify various A4 and A5 page templates, including standard lined/dotted pages, project trackers, weekly/monthly planners, OKRS, and ideas pages.

Key changes:
- **New Enums**:
    - `PageSizeEnum.kt`: Introduced to classify page sizes (`A4`, `A5`).
    - `TemplateTypeEnum.kt`: Introduced to classify different page layouts (e.g., `STANDARD_LINED`, `PROJECT_TASK_TRACKER`, `WEEKLY_PAGE`).
- **`PageTemplate.kt`**:
    - The `PageTemplate` data class was updated to use the new `PageSizeEnum` and `TemplateTypeEnum` instead of a generic `String` for the type.
- **`QrCodeTemplateMatcher.kt`**:
    - Massively expanded the `templatesMap` to include mappings for numerous official QR codes.
    - Added standardized `RocketBoundingBox` definitions for A4 and A5 pages with QR codes in bottom-left and bottom-right positions to reduce duplication.
    - Now supports various page types like dotted, lined, project trackers, and planners for both A4 and A5 sizes.
- **`SteadyFrameIndicator.kt`**:
    - Reduced `consecutiveFramesRequired` from 60 to 30 to make auto-capture faster and more responsive.
- **Logging**:
    - Added a debug log in `QrCodeHandler.kt` to output the raw value of any detected QR code, aiding in debugging and template mapping.