### PR TITLE
ci: Set APK version name from Git tag in release workflow

### DIFF
--- a/.github/workflows/publish_apk.yml
+++ b/.github/workflows/publish_apk.yml
@@ -33,7 +33,8 @@ jobs:
         KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
         KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
         KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-      run: ./gradlew assembleRelease
+        VERSION_NAME: ${{ github.event.release.tag_name }}
+      run: ./gradlew assembleRelease -PversionName="${VERSION_NAME}"
 
     - name: Upload Release APK asset
       uses: actions/upload-release-asset@v1
@@ -42,5 +43,5 @@ jobs:
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: app/build/outputs/apk/release/app-release.apk
-        asset_name: app-release.apk
+        asset_name: app-release-${{ github.event.release.tag_name }}.apk
         asset_content_type: application/vnd.android.package-archive

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         minSdk = 24
         targetSdk = 36
         versionCode = 1
-        versionName = "0.1.alpha"
+        versionName = project.findProperty("versionName") as String? ?: "0.1.alpha"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -38,16 +38,23 @@ android {
             signingConfig = signingConfigs.getByName("release")
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+
     kotlinOptions {
         jvmTarget = "11"
     }
+
     buildFeatures {
         buildConfig = true
         compose = true
+    }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
     }
 }
 


### PR DESCRIPTION
This commit updates the release process to dynamically set the Android app's `versionName` and the output APK filename from the Git tag of the GitHub release.

Key changes:
- **`app/build.gradle.kts`**:
    - The `versionName` in `defaultConfig` is now set from a Gradle project property (`-PversionName=...`). It falls back to `"0.1.alpha"` if the property is not provided, ensuring local builds still work.
    - `testOptions` were added to configure unit tests to return default values.

- **`.github/workflows/publish_apk.yml`**:
    - The `assembleRelease` Gradle command is now passed the `-PversionName` property, with its value set to the release's tag name (`${{ github.event.release.tag_name }}`).
    - The uploaded APK artifact is renamed to include the version tag (e.g., `app-release-v1.0.0.apk`) for better version tracking in GitHub Releases.