### PR TITLE
feat: Display unmatched QR codes on the overlay

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
     id("com.google.dagger.hilt.android")
 }
 
+val localVersionName = "v0.0.0.local.dev"
+val localVersionCode = 1
+
 android {
     namespace = "au.com.gman.bottlerocket"
     compileSdk = 36
@@ -14,8 +17,8 @@ android {
         applicationId = "au.com.gman.bottlerocket"
         minSdk = 24
         targetSdk = 36
-        versionCode = 1
-        versionName = project.findProperty("versionName") as String? ?: "0.1.alpha"
+        versionCode = project.findProperty("versionCode") as Int? ?: localVersionCode
+        versionName = project.findProperty("versionName") as String? ?: localVersionName
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/au/com/gman/bottlerocket/activity/CaptureActivity.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/activity/CaptureActivity.kt
@@ -76,6 +76,8 @@ class CaptureActivity : AppCompatActivity() {
     private var imageCapture: ImageCapture? = null
     private var matchFound = false
 
+    private var codeFound = false
+
     // Services
     private val apiService = ApiService("https://your-backend-url.com")
 
@@ -100,11 +102,19 @@ class CaptureActivity : AppCompatActivity() {
                 override fun onDetectionSuccess(barcodeDetectionResult: BarcodeDetectionResult) {
                     runOnUiThread {
 
+                        codeFound = barcodeDetectionResult.codeFound
                         matchFound = barcodeDetectionResult.matchFound
 
                         if (matchFound) {
                             steadyFrameIndicator.increment()
+                            overlayView.setUnmatchedQrCode(null)
                         } else {
+                            if (codeFound) {
+                                overlayView.setUnmatchedQrCode(barcodeDetectionResult.qrCode)
+                            }
+                            else {
+                                overlayView.setUnmatchedQrCode(null)
+                            }
                             steadyFrameIndicator.reset()
                         }
 
@@ -114,7 +124,6 @@ class CaptureActivity : AppCompatActivity() {
                         overlayView.setQrOverlayPath(barcodeDetectionResult.qrCodeOverlayPathPreview)
                     }
                 }
-
             })
 
         imageProcessor

--- a/app/src/main/java/au/com/gman/bottlerocket/domain/BarcodeDetectionResult.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/domain/BarcodeDetectionResult.kt
@@ -1,6 +1,7 @@
 package au.com.gman.bottlerocket.domain
 
 data class BarcodeDetectionResult(
+    val codeFound: Boolean,
     val matchFound: Boolean,
     val qrCode: String?,
     val pageTemplate: PageTemplate?,

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,4 +15,6 @@
     <color name="capture_status_green_transparent">#4496F7D0</color>
     <color name="capture_status_amber_border">#FFF7C696</color>
     <color name="capture_status_amber_transparent">#44F7C696</color>
+
+    <color name="capture_status_unmatched_code">#FFEB3B</color>
 </resources>


### PR DESCRIPTION
This commit enhances the user experience by providing visual feedback when a QR code is detected but does not match any known page template.

When an unknown QR code is scanned, its raw value is now displayed on the screen next to the detected QR code bounding box. This helps users and developers diagnose template mapping issues. The bounding box smoothing is also reset when a code is detected but not matched, preventing the overlay from lingering on an incorrect position.

Key changes:
- **`PageCaptureOverlayView.kt`**:
    - Added a new method `setUnmatchedQrCode()` to receive and display the raw value of an unmatched QR code.
    - Implemented `drawWrappedText()` using `StaticLayout` to render the QR code value near its bounding box, with word wrapping.
    - Added a new color `capture_status_unmatched_code` for the text.
- **`QrCodeHandler.kt`**:
    - Introduced a `codeFound` boolean in `BarcodeDetectionResult` to distinguish between "no code found" and "code found but not matched".
    - Logic was updated to reset the bounding box smoothing filter (`previousPageBounds` and `rocketBoundingBoxMedianFilter`) if a detected QR code does not correspond to a known template, improving UI responsiveness.
- **`CaptureActivity.kt`**:
    - Updated the detection success callback to check `codeFound` and `matchFound`.
    - If a code is found but not matched, it calls `overlayView.setUnmatchedQrCode()` to display it.
    - If no code is found, or if a match is successful, it clears the unmatched code display.
- **`build.gradle.kts`**:
    - Defined default local `versionName` and `versionCode` variables for cleaner local builds.