### PR TITLE
fix: support for legacy storage permissions and improve image saving #16

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,9 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+
     <application
         android:name=".BottleRocketApplication"
         android:allowBackup="true"

--- a/app/src/main/java/au/com/gman/bottlerocket/file/FileIo.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/file/FileIo.kt
@@ -38,8 +38,10 @@ class FileIo @Inject constructor() : IFileIo {
             val contentValues = ContentValues().apply {
                 put(MediaStore.MediaColumns.DISPLAY_NAME, name)
                 put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
-                if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
+                // For Android 10+ (API 29+)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/BottleRocket")
+                    put(MediaStore.Images.Media.IS_PENDING, 1) // Mark as pending while writing
                 }
             }
 
@@ -55,6 +57,13 @@ class FileIo @Inject constructor() : IFileIo {
                                 Bitmap.CompressFormat.JPEG, 95, outputStream
                             )
                     }
+
+                // Mark as complete (Android 10+)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    contentValues.clear()
+                    contentValues.put(MediaStore.Images.Media.IS_PENDING, 0)
+                    contentResolver.update(it, contentValues, null, null)
+                }
 
                 Log.d(TAG, "File saved: $uri")
                 listener?.onFileSaveSuccess(uri)


### PR DESCRIPTION
This commit introduces backward compatibility for storage permissions on Android 9 (API 28) and below, while refining the image saving process for newer Android versions using `MediaStore`.

Key changes:
- **Permissions**:
    - Added `WRITE_EXTERNAL_STORAGE` to `AndroidManifest.xml` with `maxSdkVersion="28"`.
    - Implemented `checkStoragePermission()` in `CaptureActivity` to request legacy storage permissions only when running on Android 9 or older.
- **`CaptureActivity.kt`**:
    - Added logic to handle storage permission requests and results.
    - Cleaned up toast notifications during image processing.
- **`FileIo.kt`**:
    - Updated `MediaStore` logic to correctly use `IS_PENDING` on Android 10 (API 29) and above, ensuring images are marked as complete only after writing is finished.
    - Corrected the SDK version check for setting the `RELATIVE_PATH`.
- **Logging**:
    - Added debug logs for Android versioning and permission status to aid in troubleshooting storage issues.