### PR TITLE
feat: Dynamic QR code template loading from API #22

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,8 +8,8 @@
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
-
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
 
     <application
@@ -24,14 +24,18 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.BottleRocket">
         <activity
+            android:name=".activity.SplashActivity"
+            android:theme="@style/Theme.BottleRocket"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".activity.MainActivity"
             android:exported="true"
             android:theme="@style/Theme.BottleRocket">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <activity
             android:name=".activity.CaptureActivity"
@@ -55,6 +59,14 @@
             android:theme="@style/Theme.BottleRocket">
             <intent-filter>
                 <action android:name="android.intent.action.SETTINGS" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".activity.ServerWarningActivity"
+            android:exported="true"
+            android:theme="@style/Theme.BottleRocket">
+            <intent-filter>
+                <action android:name="android.intent.action.SERVER_WARNING" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/au/com/gman/bottlerocket/activity/ServerWarningActivity.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/activity/ServerWarningActivity.kt
@@ -1,0 +1,54 @@
+package au.com.gman.bottlerocket.activity
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+import au.com.gman.bottlerocket.R
+import au.com.gman.bottlerocket.qrCode.QrTemplateCache
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class ServerWarningActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var templateCache: QrTemplateCache
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(R.layout.activity_server_warning)
+
+        val retryButton = findViewById<Button>(R.id.retryButton)
+        val continueButton = findViewById<Button>(R.id.continueButton)
+        val settingsButton = findViewById<Button>(R.id.settingsButton)
+
+        retryButton.setOnClickListener {
+            val intent = Intent(this, SplashActivity::class.java)
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            startActivity(intent)
+            finish()
+        }
+
+        continueButton.setOnClickListener {
+            val intent = Intent(this, MainActivity::class.java)
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            startActivity(intent)
+            finish()
+        }
+
+        settingsButton.setOnClickListener {
+            // First navigate to MainActivity to establish it in the back stack
+            val mainIntent = Intent(this, MainActivity::class.java)
+            mainIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            startActivity(mainIntent)
+
+            // Then open Settings on top of MainActivity
+            val settingsIntent = Intent(this, SettingsActivity::class.java)
+            startActivity(settingsIntent)
+
+            finish()
+        }
+    }
+}

--- a/app/src/main/java/au/com/gman/bottlerocket/activity/SplashActivity.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/activity/SplashActivity.kt
@@ -1,0 +1,56 @@
+package au.com.gman.bottlerocket.activity
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import au.com.gman.bottlerocket.R
+import au.com.gman.bottlerocket.qrCode.QrTemplateCache
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class SplashActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var templateCache: QrTemplateCache
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super
+            .onCreate(savedInstanceState)
+
+        setContentView(R.layout.activity_splash)
+
+        loadTemplatesAndProceed()
+    }
+
+    private fun loadTemplatesAndProceed() {
+        lifecycleScope.launch {
+            val result = templateCache.loadTemplates()
+
+            result.fold(
+                onSuccess = { templates ->
+                    startMainActivity()
+                },
+                onFailure = { error ->
+                    startServerWarningActivity()
+                }
+            )
+        }
+    }
+
+    private fun startMainActivity() {
+        val intent = Intent(this, MainActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        startActivity(intent)
+        finish()
+    }
+
+    private fun startServerWarningActivity() {
+        val intent = Intent(this, ServerWarningActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        startActivity(intent)
+        finish()
+    }
+}

--- a/app/src/main/java/au/com/gman/bottlerocket/contracts/FetchPageTemplatesResponse.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/contracts/FetchPageTemplatesResponse.kt
@@ -1,0 +1,15 @@
+package au.com.gman.bottlerocket.contracts
+
+import au.com.gman.bottlerocket.interfaces.IApiResponse
+import com.google.gson.annotations.SerializedName
+
+data class FetchPageTemplatesResponse(
+    @SerializedName("error_code")
+    override val errorCode: Int,
+
+    @SerializedName("error_message")
+    override val errorMessage: String,
+
+    @SerializedName("templates")
+    val templates: List<PageTemplateSummary>
+) : IApiResponse

--- a/app/src/main/java/au/com/gman/bottlerocket/contracts/PageTemplateSummary.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/contracts/PageTemplateSummary.kt
@@ -1,0 +1,11 @@
+package au.com.gman.bottlerocket.contracts
+
+import com.google.gson.annotations.SerializedName
+
+data class PageTemplateSummary(
+    @SerializedName("qr_code")
+    val qrCode: String,
+
+    @SerializedName("book_vendor")
+    val bookVendor: String
+)

--- a/app/src/main/java/au/com/gman/bottlerocket/domain/PageTemplate.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/domain/PageTemplate.kt
@@ -1,7 +1,6 @@
 package au.com.gman.bottlerocket.domain
 
 data class PageTemplate(
-    val pageSize: PageSizeEnum,
-    val templateType: TemplateTypeEnum,
-    val pageDimensions: RocketBoundingBox
+    val qrCode: String,
+    val bookVendor: String
 )

--- a/app/src/main/java/au/com/gman/bottlerocket/injection/QrModule.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/injection/QrModule.kt
@@ -3,14 +3,17 @@ import au.com.gman.bottlerocket.interfaces.IEdgeDetector
 import au.com.gman.bottlerocket.interfaces.IQrCodeHandler
 import au.com.gman.bottlerocket.interfaces.IQrCodeTemplateMatcher
 import au.com.gman.bottlerocket.interfaces.IQrPositionalValidator
-import au.com.gman.bottlerocket.qrCode.QrEdgeDetector
-import au.com.gman.bottlerocket.qrCode.QrCodeHandler
+import au.com.gman.bottlerocket.interfaces.IQrTemplateCache
 import au.com.gman.bottlerocket.qrCode.QrCodeTemplateMatcher
+import au.com.gman.bottlerocket.qrCode.QrCodeHandler
+import au.com.gman.bottlerocket.qrCode.QrEdgeDetector
 import au.com.gman.bottlerocket.qrCode.QrPositionalValidator
+import au.com.gman.bottlerocket.qrCode.QrTemplateCache
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -23,6 +26,7 @@ abstract class QrModule {
 
     @Binds
     abstract fun bindQrCodeTemplateMatcher(
+//        templateMapper: QrCodeTemplateMatcher
         templateMapper: QrCodeTemplateMatcher
     ) : IQrCodeTemplateMatcher
 
@@ -35,4 +39,10 @@ abstract class QrModule {
     abstract fun bindQrEdgeDetector(
         qrEdgeDetector: QrEdgeDetector
     ) : IEdgeDetector
+
+    @Singleton
+    @Binds
+    abstract fun bindQrTemplateCache(
+        qrTemplateCache: QrTemplateCache
+    ): IQrTemplateCache
 }

--- a/app/src/main/java/au/com/gman/bottlerocket/interfaces/IApiResponseListener.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/interfaces/IApiResponseListener.kt
@@ -1,12 +1,15 @@
 package au.com.gman.bottlerocket.interfaces
 
 import au.com.gman.bottlerocket.contracts.ConnectionTestResponse
+import au.com.gman.bottlerocket.contracts.FetchPageTemplatesResponse
 import au.com.gman.bottlerocket.contracts.ProcessCaptureResponse
 
 interface IApiResponseListener {
     fun onApiProcessCaptureSuccess(response: ProcessCaptureResponse) = Unit
 
     fun onApiConnectionTestSuccess(response: ConnectionTestResponse) = Unit
+
+    fun onApiFetchTemplatesSuccess(response: FetchPageTemplatesResponse) = Unit
 
     fun onApiResponseFailure(response: IApiResponse) = Unit
 }

--- a/app/src/main/java/au/com/gman/bottlerocket/interfaces/IApiService.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/interfaces/IApiService.kt
@@ -17,4 +17,6 @@ interface IApiService {
     )
 
     fun setListener(listener: IApiResponseListener)
+
+    fun downloadTemplates()
 }

--- a/app/src/main/java/au/com/gman/bottlerocket/interfaces/IQrTemplateCache.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/interfaces/IQrTemplateCache.kt
@@ -1,0 +1,11 @@
+package au.com.gman.bottlerocket.interfaces
+
+import au.com.gman.bottlerocket.contracts.PageTemplateSummary
+
+interface IQrTemplateCache {
+    suspend fun loadTemplates(): Result<List<PageTemplateSummary>>
+
+    fun getTemplates(): List<PageTemplateSummary>
+
+    fun isTemplatesLoaded(): Boolean
+}

--- a/app/src/main/java/au/com/gman/bottlerocket/interfaces/IRetrofitApi.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/interfaces/IRetrofitApi.kt
@@ -1,10 +1,12 @@
 package au.com.gman.bottlerocket.interfaces
 
 import au.com.gman.bottlerocket.contracts.ConnectionTestResponse
+import au.com.gman.bottlerocket.contracts.FetchPageTemplatesResponse
 import au.com.gman.bottlerocket.contracts.ProcessCaptureResponse
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.Response
+import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
@@ -21,4 +23,8 @@ interface IRetrofitApi {
     @POST("/api/connection")
     suspend fun apiConnectionTest()
             : Response<ConnectionTestResponse>
+
+    @GET("/api/pageTemplates")
+    suspend fun apiFetchPageTemplates()
+            : Response<FetchPageTemplatesResponse>
 }

--- a/app/src/main/java/au/com/gman/bottlerocket/qrCode/QrCodeTemplateMatcher.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/qrCode/QrCodeTemplateMatcher.kt
@@ -1,133 +1,24 @@
 package au.com.gman.bottlerocket.qrCode
 
-import android.graphics.PointF
-import au.com.gman.bottlerocket.domain.PageSizeEnum
 import au.com.gman.bottlerocket.domain.PageTemplate
-import au.com.gman.bottlerocket.domain.RocketBoundingBox
-import au.com.gman.bottlerocket.domain.TemplateTypeEnum
 import au.com.gman.bottlerocket.interfaces.IQrCodeTemplateMatcher
+import au.com.gman.bottlerocket.interfaces.IQrTemplateCache
 import javax.inject.Inject
-import kotlin.collections.get
 
-class QrCodeTemplateMatcher @Inject constructor() : IQrCodeTemplateMatcher {
-
-    companion object {
-        private val STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT =
-            RocketBoundingBox(
-                topLeft = PointF(0f, -11.0f),
-                topRight = PointF(9.0f, -11.0f),
-                bottomRight = PointF(9.0f, 1.0f),
-                bottomLeft = PointF(0f, 1.0f)
-            )
-
-        private val STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT =
-            RocketBoundingBox(
-                topLeft = PointF(-8.0f, -11.0f),
-                topRight = PointF(1.0f, -11.0f),
-                bottomRight = PointF(1.0f, 1.0f),
-                bottomLeft = PointF(-8.0f, 1.0f)
-            )
-
-        private val STANDARD_A5_BOUNDS_QR_BOTTOM_LEFT =
-            RocketBoundingBox(
-                topLeft = PointF(0f, -25.0f),
-                topRight = PointF(15.5f, -25.0f),
-                bottomRight = PointF(15.5f, 1.0f),
-                bottomLeft = PointF(0f, 1.0f)
-            )
-
-        private val STANDARD_A5_BOUNDS_QR_BOTTOM_RIGHT =
-            RocketBoundingBox(
-                topLeft = PointF(-14.5f, -25.0f),
-                topRight = PointF(1.0f, -25.0f),
-                bottomRight = PointF(1.0f, 1.0f),
-                bottomLeft = PointF(-14.5f, 1.0f)
-            )
-    }
-
-    val templatesMap = mapOf(
-        "04o" to PageTemplate(
-            templateType = TemplateTypeEnum.STANDARD_LINED,
-            pageSize = PageSizeEnum.A5,
-            pageDimensions = STANDARD_A5_BOUNDS_QR_BOTTOM_LEFT
-        ),
-        "04p" to PageTemplate(
-            templateType = TemplateTypeEnum.STANDARD_DOTTED,
-            pageSize = PageSizeEnum.A5,
-            pageDimensions = STANDARD_A5_BOUNDS_QR_BOTTOM_RIGHT
-        ),
-        "P01 V1F T02 S000" to PageTemplate(
-            templateType = TemplateTypeEnum.STANDARD_LINED,
-            pageSize = PageSizeEnum.A4,
-            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
-        ),
-        "P01 V17 T02 S000" to PageTemplate(
-            templateType = TemplateTypeEnum.STANDARD_LINED,
-            pageSize = PageSizeEnum.A4,
-            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
-        ),
-        "P02 V1F T02 S000" to PageTemplate(
-            templateType = TemplateTypeEnum.STANDARD_LINED,
-            pageSize = PageSizeEnum.A4,
-            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT
-        ),
-        "P02 V17 T02 S000" to PageTemplate(
-            templateType = TemplateTypeEnum.STANDARD_LINED,
-            pageSize = PageSizeEnum.A4,
-            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT
-        ),
-        "P01 V17 T01 S000" to PageTemplate(
-            templateType = TemplateTypeEnum.STANDARD_DOTTED,
-            pageSize = PageSizeEnum.A4,
-            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
-        ),
-        "P02 V17 T01 S000" to PageTemplate(
-            templateType = TemplateTypeEnum.STANDARD_DOTTED,
-            pageSize = PageSizeEnum.A4,
-            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT
-        ),
-        "P01 V17 T03 S000" to PageTemplate(
-            templateType = TemplateTypeEnum.PROJECT_TASK_TRACKER,
-            pageSize = PageSizeEnum.A4,
-            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
-        ),
-        "P01 V17 T04 S000" to PageTemplate(
-            templateType = TemplateTypeEnum.WEEKLY_PAGE,
-            pageSize = PageSizeEnum.A4,
-            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT
-        ),
-        "P02 V17 T04 S000" to PageTemplate(
-            templateType = TemplateTypeEnum.WEEKLY_PAGE,
-            pageSize = PageSizeEnum.A4,
-            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
-        ),
-        "P01 V17 T05 S000" to PageTemplate(
-            templateType = TemplateTypeEnum.MONTHLY_PAGE,
-            pageSize = PageSizeEnum.A4,
-            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT
-        ),
-        "P01 V17 T06 S000" to PageTemplate(
-            templateType = TemplateTypeEnum.OKRS_PAGE,
-            pageSize = PageSizeEnum.A4,
-            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
-        ),
-        "P01 V17 T06 S000" to PageTemplate(
-            templateType = TemplateTypeEnum.OKRS_PAGE,
-            pageSize = PageSizeEnum.A4,
-            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_LEFT
-        ),
-        "P01 V17 T07 S000" to PageTemplate(
-            templateType = TemplateTypeEnum.IDEAS_PAGE,
-            pageSize = PageSizeEnum.A4,
-            pageDimensions = STANDARD_A4_BOUNDS_QR_BOTTOM_RIGHT
-        )
-    )
+class QrCodeTemplateMatcher @Inject constructor(
+    private val templateCache: IQrTemplateCache
+) : IQrCodeTemplateMatcher {
 
     override fun tryMatch(qrCode: String?): PageTemplate? {
-        return if (qrCode in templatesMap) {
-            templatesMap[qrCode]
-        } else {
-            null
-        }
+        if (qrCode == null) return null
+
+        val template = templateCache.getTemplates()
+            .firstOrNull { it.qrCode == qrCode }
+            ?: return null
+
+        return PageTemplate(
+            qrCode = template.qrCode,
+            bookVendor = template.bookVendor
+        )
     }
 }

--- a/app/src/main/java/au/com/gman/bottlerocket/qrCode/QrTemplateCache.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/qrCode/QrTemplateCache.kt
@@ -1,0 +1,51 @@
+package au.com.gman.bottlerocket.qrCode
+
+import au.com.gman.bottlerocket.contracts.PageTemplateSummary
+import au.com.gman.bottlerocket.interfaces.IQrTemplateCache
+import au.com.gman.bottlerocket.interfaces.IRetrofitApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class QrTemplateCache @Inject constructor(
+    private val retrofitApi: IRetrofitApi
+) : IQrTemplateCache {
+    private var templates: List<PageTemplateSummary> = emptyList()
+    private var isLoaded = false
+
+    companion object {
+        private const val TEMPLATE_LOAD_TIMEOUT_MS = 5000L // 5 seconds
+    }
+
+    override suspend fun loadTemplates(): Result<List<PageTemplateSummary>> {
+        return withContext(Dispatchers.IO) {
+            try {
+                withTimeout(TEMPLATE_LOAD_TIMEOUT_MS) {
+                    val response = retrofitApi.apiFetchPageTemplates()
+
+                    if (response.isSuccessful && response.body() != null) {
+                        val body = response.body()!!
+                        if (body.isSuccess()) {
+                            templates = body.templates.toList()
+                            isLoaded = true
+                            Result.success(templates)
+                        } else {
+                            Result.failure(Exception(body.errorMessage))
+                        }
+                    } else {
+                        Result.failure(Exception("HTTP Error: ${response.code()}"))
+                    }
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+    }
+
+    override fun getTemplates(): List<PageTemplateSummary> = templates
+
+    override fun isTemplatesLoaded(): Boolean = isLoaded
+}

--- a/app/src/main/res/layout/activity_server_warning.xml
+++ b/app/src/main/res/layout/activity_server_warning.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bottle_rocket_dark">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/apiServerUrlHelper"
+            style="@style/Theme.BottleRocket.Warning"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="18dp"
+            android:text="@string/warning_server"
+            android:textAlignment="center"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <Button
+            android:id="@+id/retryButton"
+            style="@style/Theme.BottleRocket.Button"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:layout_marginHorizontal="32dp"
+            android:layout_marginVertical="10dp"
+            android:text="@string/retry" />
+
+        <Button
+            android:id="@+id/continueButton"
+            style="@style/Theme.BottleRocket.Button"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:layout_marginHorizontal="32dp"
+            android:layout_marginVertical="16dp"
+            android:enabled="true"
+            android:text="@string/continue_to_main" />
+
+        <Button
+            android:id="@+id/settingsButton"
+            style="@style/Theme.BottleRocket.Button"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:layout_marginHorizontal="32dp"
+            android:layout_marginVertical="16dp"
+            android:text="@string/option_settings" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bottle_rocket_dark">
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/apiServerUrlHelper"
+        style="@style/Theme.BottleRocket.TextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="18dp"
+        android:text="@string/loading_templates"
+        app:layout_constraintTop_toBottomOf="@id/progressBar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,6 +9,7 @@
     <color name="bottle_rocket_dark">#FF093624</color>
     <color name="bottle_rocket_light">#FF96F7D0</color>
     <color name="bottle_rocket_light_disabled">#5596F7D0</color>
+    <color name="warning">#fff6d06f</color>
     <color name="debug_text">#FFFF0000</color>
 
     <color name="capture_status_green_border">#FF96F7D0</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,9 @@
     <string name="user_name">User name</string>
     <string name="password">Password</string>
     <string name="bottle_rocket_logo">Bottle Rocket logo</string>
+    <string name="title_activity_splash">SplashActivity</string>
+    <string name="loading_templates">Loading templates…</string>
+    <string name="continue_to_main">Continue</string>
+    <string name="warning_server">Warning - could not connect to Bottle Rocket server. \nPlease verify your Bottle Rocket server in order to detect QR code pages.</string>
+    <string name="retry">Retry</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
+
     <style name="Theme.BottleRocket" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Primary brand color -->
         <item name="colorPrimary">@color/primary_color_selector</item>
@@ -7,17 +8,20 @@
         <item name="android:colorBackground">@color/bottle_rocket_dark</item>
         <!-- Customize other theme attributes here -->
     </style>
+
     <style name="Theme.BottleRocket.Button" parent="Widget.AppCompat.Button">
         <item name="android:textColor">@color/primary_color_selector</item>
         <item name="android:background">@drawable/custom_button</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:fontFamily">@font/jet_brains_mono</item>
     </style>
+
     <style name="Theme.BottleRocket.TextView" parent="Widget.AppCompat.TextView">
         <item name="android:textColor">@color/white</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:fontFamily">@font/jet_brains_mono</item>
     </style>
+
     <style name="Theme.BottleRocket.EditText" parent="Widget.AppCompat.EditText">
         <item name="android:textColor">@color/bottle_rocket_light</item>
         <item name="android:textColorHint">@color/white</item>
@@ -25,12 +29,20 @@
         <item name="android:textAllCaps">false</item>
         <item name="android:fontFamily">@font/jet_brains_mono</item>
     </style>
+
     <style name="Theme.BottleRocket.TextDebug" parent="Widget.AppCompat.TextView">
         <item name="android:textColor">@color/debug_text</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:fontFamily">@font/jet_brains_mono</item>
         <item name="android:textSize">6pt</item>
     </style>
+
+    <style name="Theme.BottleRocket.Warning" parent="Widget.AppCompat.TextView">
+        <item name="android:textColor">@color/warning</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:fontFamily">@font/jet_brains_mono</item>
+    </style>
+
     <style name="Theme.BottleRocket.BorderedImageView">
         <item name="android:background">@drawable/image_border</item>
         <item name="android:padding">2dp</item>


### PR DESCRIPTION
This commit replaces the hardcoded `QrCodeTemplateMatcher` with a dynamic system that fetches and caches page templates from the Bottle Rocket server.

Key changes:
- **New Activities**: Added `SplashActivity` to handle template loading at startup and `ServerWarningActivity` to provide retry/bypass options if the server is unreachable.
- **Dynamic Templates**:
    - Created `IQrTemplateCache` and `QrTemplateCache` to manage template data.
    - Updated `QrCodeTemplateMatcher` to use the cached templates for matching.
    - Updated `PageTemplate` domain model to focus on `qrCode` and `bookVendor`.
- **API Integration**:
    - Added `/api/pageTemplates` GET endpoint to `IRetrofitApi`.
    - Implemented `downloadTemplates()` in `ApiService`.
    - Added `FetchPageTemplatesResponse` and `PageTemplateSummary` contracts.
- **UI/UX**:
    - Defined new layouts for splash and server warning screens.
    - Added corresponding string resources, colors, and themes for warnings and loading states.
    - Updated `AndroidManifest.xml` to set `SplashActivity` as the new launcher.
- **Dependency Injection**: Updated `QrModule` to bind the new template cache and matcher.