### PR TITLE
chore: Trim QR code string before template matching #31

### DIFF
--- a/app/src/main/java/au/com/gman/bottlerocket/qrCode/QrCodeTemplateMatcher.kt
+++ b/app/src/main/java/au/com/gman/bottlerocket/qrCode/QrCodeTemplateMatcher.kt
@@ -13,7 +13,7 @@ class QrCodeTemplateMatcher @Inject constructor(
         if (qrCode == null) return null
 
         val template = templateCache.getTemplates()
-            .firstOrNull { it.qrCode == qrCode }
+            .firstOrNull { it.qrCode == qrCode.trim() }
             ?: return null
 
         return PageTemplate(


### PR DESCRIPTION
This commit adds a `.trim()` call to the QR code string in `QrCodeTemplateMatcher.kt` to ensure more robust matching against the template cache by removing any leading or trailing whitespace.